### PR TITLE
PreparedGeometry needs to reference prepared Geometry to prevent GC reaping.

### DIFF
--- a/lib/ffi-geos/geometry.rb
+++ b/lib/ffi-geos/geometry.rb
@@ -466,7 +466,7 @@ module Geos
     end
 
     def to_prepared
-      Geos::PreparedGeometry.new(FFIGeos.GEOSPrepare_r(Geos.current_handle, self.ptr))
+      Geos::PreparedGeometry.new(FFIGeos.GEOSPrepare_r(Geos.current_handle, self.ptr), self)
     end
 
     def to_s

--- a/lib/ffi-geos/prepared_geometry.rb
+++ b/lib/ffi-geos/prepared_geometry.rb
@@ -3,11 +3,12 @@ module Geos
   class PreparedGeometry
     include Geos::Tools
 
-    attr_reader :ptr
+    attr_reader :ptr, :geometry
 
     undef :clone, :dup
 
-    def initialize(ptr, auto_free = true)
+    def initialize(ptr, geometry, auto_free = true)
+      @geometry = geometry
       @ptr = FFI::AutoPointer.new(
         ptr,
         auto_free ? self.class.method(:release) : self.class.method(:no_release)


### PR DESCRIPTION
PreparedGeometries need to store a reference to their Geometry in Ruby, or the Ruby garbage collector will pick them up when the source Geometry is no longer referenced.

View this test case:

```
@polygons = []

1000.times do |i| 
  cs = Geos::CoordinateSequence.new(5, 2)
  cs.set_x(0, 0)
  cs.set_y(0, 0)
  cs.set_x(1, 0)
  cs.set_y(1, 10)
  cs.set_x(2, 10)
  cs.set_y(2, 10)
  cs.set_x(3, 10)
  cs.set_y(3, 0)
  cs.set_x(4, 0)
  cs.set_y(4, 0)

  exterior_ring         = Geos::create_linear_ring(cs)
  geom                  = Geos::create_polygon(exterior_ring)
  compare_exterior_ring = Geos::create_linear_ring(cs.clone)
  compare_geom          = Geos::create_polygon(compare_exterior_ring)
  prepared_geom         = geom.to_prepared

  @polygons << prepared_geom
end

cs = Geos::CoordinateSequence.new(1)
cs.set_y(0, 0)
cs.set_x(0, 0)
point = Geos.create_point(cs)

@polygons.any? { |polygon| polygon.contains?(point) }
```

This code works fine if the @polygons array is loaded with Geometry objects, but not when it contains PreparedGeometry objects.  Also, running GC.disable at the start of the object creation also allows this code to execute fine.  

The problems that exists is when PreparedGeometry objects are created they reference the Geometry objects in memory.  If these are no longer referenced directly in Ruby, the garbage collector will destroy these objects, causing a segmentation fault when libgeos attempts to work with the Geometry object as it's no longer valid.

This solves this problem by storing the Geometry object, tied to the PreparedGeometry, which is completely valid and prevents it from being picked up by the garbage collector.
