### PR TITLE
Remove duplicate disjoint? definition

### DIFF
--- a/lib/ffi-geos/geometry.rb
+++ b/lib/ffi-geos/geometry.rb
@@ -280,11 +280,6 @@ module Geos
       end
     end
 
-    def disjoint?(geom)
-      check_geometry(geom)
-      bool_result(FFIGeos.GEOSDisjoint_r(Geos.current_handle, self.ptr, geom.ptr))
-    end
-
     def eql?(geom)
       check_geometry(geom)
       bool_result(FFIGeos.GEOSEquals_r(Geos.current_handle, self.ptr, geom.ptr))


### PR DESCRIPTION
Hi J,

Just removing a duplicate definition of Geometry#disjoint? to eliminate a warning.
