### PR TITLE
Add support for serializing/deserializing geometries via yaml

### DIFF
--- a/lib/ffi-geos.rb
+++ b/lib/ffi-geos.rb
@@ -1152,4 +1152,6 @@ module Geos
 
   include GeomTypes
   include VersionConstants
+
+  require File.join(GEOS_BASE, 'yaml')
 end

--- a/lib/ffi-geos/yaml.rb
+++ b/lib/ffi-geos/yaml.rb
@@ -1,0 +1,42 @@
+# encoding: UTF-8
+
+# This file adds yaml serialization support to geometries.  The generated yaml
+# has this format:
+#
+#    !ruby/object:Geos::Geometry
+#    wkt: POINT (-104.97 39.71)
+#    srid: 4326
+#
+#  So to use this in a rails fixture file you could do something like this:
+#
+#    geometry_1:
+#      id: 1
+#      geom: !ruby/object:Geos::Geometry
+#        wkt: POINT (-104.97 39.71)
+#        srid: 4326
+#
+# Note this code assumes the use of Psych (not syck) and ruby 1.9 and higher
+
+require 'yaml'
+
+module Geos
+  class Geometry
+    def init_with(coder)
+      # Convert wkt to a geos pointer
+      reader = Geos::WktReader.new
+      geom_ptr = FFIGeos.GEOSWKTReader_read_r(Geos.current_handle, reader.ptr, coder['wkt'])
+
+      # Now setup this objects pointer to be the pointer we just created
+      @ptr = FFI::AutoPointer.new(geom_ptr, self.class.method(:release))
+      self.srid = coder['srid']
+    end
+
+    def encode_with(coder)
+      writer = Geos::WktWriter.new
+      # Note we enforce ascii encoding so the wkt in the yaml file is readable - otherwise
+      # psych converts it to a binary string
+      coder['wkt'] = writer.write(self).force_encoding('ASCII')
+      coder['srid'] = self.srid
+    end
+  end
+end

--- a/test/yaml_tests.rb
+++ b/test/yaml_tests.rb
@@ -1,0 +1,92 @@
+# encoding: UTF-8
+
+$: << File.dirname(__FILE__)
+require 'test_helper'
+
+class YamlTests < MiniTest::Unit::TestCase
+  include TestHelper
+
+  def test_point
+    geom = read('POINT(5 7)')
+    geom.srid = 4326
+
+    yaml = YAML.dump(geom)
+    expected = <<-EOS
+--- !ruby/object:Geos::Point
+wkt: POINT (5.0000000000000000 7.0000000000000000)
+srid: 4326
+EOS
+    assert_equal(expected, yaml)
+
+    new_geom = YAML.load(yaml)
+    assert_kind_of(Geos::Point, new_geom)
+    assert_equal(4326, new_geom.srid)
+    assert_equal(5, new_geom.x)
+    assert_equal(7, new_geom.y)
+  end
+
+  def test_line
+    geom = read('LINESTRING (0 0, 10 10)')
+    geom.srid = 4326
+
+    yaml = YAML.dump(geom)
+    expected = <<-EOS
+--- !ruby/object:Geos::LineString
+wkt: LINESTRING (0.0000000000000000 0.0000000000000000, 10.0000000000000000 10.0000000000000000)
+srid: 4326
+    EOS
+    assert_equal(expected, yaml)
+
+    new_geom = YAML.load(yaml)
+    assert_kind_of(Geos::LineString, new_geom)
+
+    assert_equal(2, new_geom.num_points)
+
+    point = geom.point_n(0)
+    assert_equal(0, point.x)
+    assert_equal(0, point.y)
+
+    point = geom.point_n(1)
+    assert_equal(10, point.x)
+    assert_equal(10, point.y)
+  end
+
+  def test_polygon
+    geom = read('POLYGON ((0 0, 5 0, 5 5, 0 5, 0 0))')
+    geom.srid = 4326
+
+    yaml = YAML.dump(geom)
+    expected = <<-EOS
+--- !ruby/object:Geos::Polygon
+wkt: POLYGON ((0.0000000000000000 0.0000000000000000, 5.0000000000000000 0.0000000000000000,
+  5.0000000000000000 5.0000000000000000, 0.0000000000000000 5.0000000000000000, 0.0000000000000000
+  0.0000000000000000))
+srid: 4326
+    EOS
+    assert_equal(expected, yaml)
+
+    new_geom = YAML.load(yaml)
+    assert_kind_of(Geos::Polygon, new_geom)
+
+    assert_equal(0, new_geom.num_interior_rings)
+    assert_equal(5, new_geom.exterior_ring.num_points)
+  end
+
+  def test_geometry_collection
+    geom = read('GEOMETRYCOLLECTION (POINT(5 7))')
+    geom.srid = 4326
+
+    yaml = YAML.dump(geom)
+    expected = <<-EOS
+--- !ruby/object:Geos::GeometryCollection
+wkt: GEOMETRYCOLLECTION (POINT (5.0000000000000000 7.0000000000000000))
+srid: 4326
+    EOS
+    assert_equal(expected, yaml)
+
+    new_geom = YAML.load(yaml)
+    assert_kind_of(Geos::GeometryCollection, new_geom)
+    assert_equal(1, new_geom.to_a.count)
+    assert_equal(4326, new_geom.srid)
+  end
+end


### PR DESCRIPTION
This patch add support for serializing/deserializing geometries to YAML.  This is helfpul for setting up fixture files in Rails.  Note it assumes the use of psych (instead of the deprecated syck) and ruby 1.9.  Ruby 1.9 is required due to a call to force_encoding, but that could be fixed easily (and then syck support would have to be added though).
