### PR TITLE
Enable Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: ruby
+rvm:
+  - 2.1.0
+  - 2.0.0
+  - 1.9.3
+  - 1.8.7
+  - rbx
+before_install:
+  - sudo apt-get update
+  - sudo apt-get install libgeos-dev libproj-dev

--- a/Gemfile
+++ b/Gemfile
@@ -6,10 +6,16 @@ gem "rdoc", "~> 3.12"
 gem "rake", "~> 10.0"
 gem "minitest"
 gem "minitest-reporters"
-gem "guard-minitest"
+
+platforms :rbx do
+  gem 'rubysl', '~> 2.0'
+  gem 'rubinius-developer_tools'
+end
+
 
 if RUBY_VERSION >= '1.9'
   gem "simplecov"
+  gem 'guard-minitest'
 end
 
 if File.exists?('Gemfile.local')

--- a/Rakefile
+++ b/Rakefile
@@ -18,10 +18,16 @@ Rake::TestTask.new(:test) do |t|
   t.warning = !!ENV['WARNINGS']
 end
 
-desc 'Build docs'
-Rake::RDocTask.new do |t|
-  t.title = "ffi-geos #{version}"
-  t.main = 'README.rdoc'
-  t.rdoc_dir = 'doc'
-  t.rdoc_files.include('README.rdoc', 'MIT-LICENSE', 'lib/**/*.rb')
+task :default => :test
+
+begin
+  desc 'Build docs'
+  Rake::RDocTask.new do |t|
+    t.title = "ffi-geos #{version}"
+    t.main = 'README.rdoc'
+    t.rdoc_dir = 'doc'
+    t.rdoc_files.include('README.rdoc', 'MIT-LICENSE', 'lib/**/*.rb')
+  end
+rescue LoadError
+  puts 'Rake::RDocTask is not supported on this platform.'
 end


### PR DESCRIPTION
This PR includes a few changes:
1. Added .travis.yml
2. Added Rubinius gems to Gemfile, so that specs can be run under Rubinius
3. Updated Rakefile so that the test task is the default task.

After this PR is merged @dark-panda will need to go to http://travis-ci.org and enable CI for this repository.  Subsequently all PRs and changes to branches will trigger CI runs.

A few quick comments:
1. I left Ruby 1.9.2 out of the Travis test matrix because the Gemfile was going to be a pain - the latest guard-minitest doesn't support 1.9.2.  As 1.9.2 is not a recommended Ruby at this point this seemed ok.
2. Specs are not running cleanly against JRuby at this point.  So I left JRuby out of the test matrix.  I hope to have time to take a look at the JRuby issues in the next week or so.

With this PR the specs run green on all platforms.  You can see a run here - https://travis-ci.org/petergoldstein/ffi-geos/builds/16970136
