### PR TITLE
Explicitly coerce coordinates to floats

### DIFF
--- a/lib/ffi-geos/coordinate_sequence.rb
+++ b/lib/ffi-geos/coordinate_sequence.rb
@@ -109,7 +109,7 @@ module Geos
       if points
         points.each_with_index do |point, idx|
           point.each_with_index do |val, dim|
-            self.set_ordinate(idx, dim, val)
+            self.set_ordinate(idx, dim, val.to_f)
           end
         end
       end

--- a/lib/ffi-geos/utils.rb
+++ b/lib/ffi-geos/utils.rb
@@ -38,10 +38,10 @@ module Geos
           cs = args.first
         elsif args.length == 2
           cs = CoordinateSequence.new(1, 2)
-          cs.x[0], cs.y[0] = args[0], args[1]
+          cs.x[0], cs.y[0] = args[0].to_f, args[1].to_f
         elsif args.length == 3
           cs = CoordinateSequence.new(1, 3)
-          cs.x[0], cs.y[0], cs.z[0] = args
+          cs.x[0], cs.y[0], cs.z[0] = args.map(&:to_f)
         else
           raise ArgumentError.new("Wrong number of arguments (#{args.length} for 1-3)")
         end


### PR DESCRIPTION
Explicitly coerce coordinates to floats, so that they are converted properly by FFI under JRuby.  This fixes a number of failing specs under JRuby.
